### PR TITLE
Adding rspec-expectations as a dependency

### DIFF
--- a/swagger-diff.gemspec
+++ b/swagger-diff.gemspec
@@ -23,6 +23,7 @@ and helper functions that can be used directly.'
   spec.require_paths = ['lib']
 
   spec.add_dependency 'swagger-core', '~> 0.2.3'
+  spec.add_dependency 'rspec-expectations', '~> 3.3'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.4'
   spec.add_development_dependency 'rspec', '~> 3.3'


### PR DESCRIPTION
The RSpec matcher requires RSpec Expectations to be installed. Adding rspec-expectations as a dependency, leaving rspec as a development dependency.

This was missed during testing because we didn't test installing the built gem in a clean environment. Verified that this works by building the gem locally then testing in a clean Docker container.
