### PR TITLE
Allow required children of new optional parents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Change Log
+
+## master (unreleased)
+
+### Bugs Fixed
+
+* [#3](https://github.com/civisanalytics/swagger-diff/pull/3)
+  treat required elements in new child parameters as backwards-compatible
+
+## 1.0.1 (2015-10-01)
+
+### Bugs Fixed
+
+* [#1](https://github.com/civisanalytics/swagger-diff/pull/1)
+  added missing rspec-expectations dependency
+
+## 1.0.0 (2015-10-01)
+
+* Initial Release

--- a/lib/swagger/diff/diff.rb
+++ b/lib/swagger/diff/diff.rb
@@ -80,12 +80,20 @@ module Swagger
         ret
       end
 
+      def new_child?(req, old)
+        idx = req.rindex('/')
+        return false unless idx
+        key = req[0..idx]
+        !old.any? { |param| param.start_with?(key) }
+      end
+
       def incompatible_request_params_enumerator
         Enumerator.new do |yielder|
           @old_specification.request_params.each do |key, old_params|
             new_params = @new_specification.request_params[key]
             next if new_params.nil?
             (new_params[:required] - old_params[:required]).each do |req|
+              next if new_child?(req, old_params[:all])
               yielder << [key, "new required request param: #{req}"]
             end
             (old_params[:all] - new_params[:all]).each do |req|

--- a/spec/fixtures/dummy.v1.json
+++ b/spec/fixtures/dummy.v1.json
@@ -150,6 +150,18 @@
             }
           }
         }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "",
+            "in": "body",
+            "schema": { "$ref": "#/definitions/C2" }
+          }
+        ],
+        "responses": {
+          "204": {}
+        }
       }
     }
   },
@@ -249,6 +261,28 @@
       "properties": {
         "id": { "type": "integer" },
         "name": { "type": "string" }
+      }
+    },
+    "C2": {
+      "type": "object",
+      "properties": {
+        "existing": { "$ref": "#/definitions/C3" }
+      }
+    },
+    "C3": {
+      "type": "object",
+      "required": [ "a" ],
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "string" }
+      }
+    },
+    "C4": {
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "string" }
       }
     }
   }

--- a/spec/fixtures/dummy.v2.json
+++ b/spec/fixtures/dummy.v2.json
@@ -100,6 +100,18 @@
             }
           }
         }
+      },
+      "post": {
+        "parameters": [
+          {
+            "name": "",
+            "in": "body",
+            "schema": { "$ref": "#/definitions/C2" }
+          }
+        ],
+        "responses": {
+          "204": {}
+        }
       }
     }
   },
@@ -192,6 +204,29 @@
       "type": "object",
       "properties": {
         "id": { "type": "integer" }
+      }
+    },
+    "C2": {
+      "type": "object",
+      "properties": {
+        "existing": { "$ref": "#/definitions/C3" },
+        "new": { "$ref": "#/definitions/C4" }
+      }
+    },
+    "C3": {
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "string" }
+      }
+    },
+    "C4": {
+      "type": "object",
+      "required": [ "a", "b" ],
+      "properties": {
+        "a": { "type": "string" },
+        "b": { "type": "string" }
       }
     }
   }

--- a/spec/swagger/diff/diff_spec.rb
+++ b/spec/swagger/diff/diff_spec.rb
@@ -29,7 +29,8 @@ describe Swagger::Diff::Diff do
                                  'missing request param: obj/thing (type: integer)',
                                  'missing request param: str (type: string)'
                                 ],
-               'put /b/{}' => ['new required request param: extra'] },
+               'put /b/{}' => ['new required request param: extra'],
+               'post /c/' => ['new required request param: existing/b'] },
              response_attributes: {
                'post /a/' => ['missing attribute from 200 response: description (type: string)'],
                'get /a/{}' => ['missing attribute from 200 response: description (type: string)'],
@@ -54,6 +55,8 @@ describe Swagger::Diff::Diff do
     - missing request param: str (type: string)
   - post /a/
     - new required request param: extra
+  - post /c/
+    - new required request param: existing/b
   - put /b/{}
     - new required request param: extra
 - incompatible response attributes

--- a/spec/swagger/diff/rspec_matchers_spec.rb
+++ b/spec/swagger/diff/rspec_matchers_spec.rb
@@ -27,6 +27,8 @@ expected Swagger to be compatible with 'spec/fixtures/dummy.v1.json', found:
     - missing request param: str (type: string)
   - post /a/
     - new required request param: extra
+  - post /c/
+    - new required request param: existing/b
   - put /b/{}
     - new required request param: extra
 - incompatible response attributes


### PR DESCRIPTION
If a POST/PUT/PATCH is modified to add a new optional child element that is a reference to a nested schema with required elements, that should be considered backwards-compatible.

Adding a changelog detailing this (and the 1.0.1 release).

Fixes #2.