### PR TITLE
Fixing parsing of header and formData parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.3 (TBD)
+
+### Bugs Fixed
+
+* [#8](https://github.com/civisanalytics/swagger-diff/pull/8)
+  fixed parsing of header and formData parameters
+
 ## 1.0.2 (2015-10-08)
 
 ### Bugs Fixed

--- a/lib/swagger/diff/specification.rb
+++ b/lib/swagger/diff/specification.rb
@@ -161,11 +161,11 @@ module Swagger
         ret = { required: Set.new, all: Set.new }
         return ret if params.nil?
         params.each do |param|
-          if param.in == 'path' || param.in == 'query'
+          if param.in == 'body'
+            merge_refs!(ret, refs(param.schema['$ref']))
+          else
             ret[:required].add(param.name) if param.required
             ret[:all].add("#{param.name} (type: #{param.type})")
-          else
-            merge_refs!(ret, refs(param.schema['$ref']))
           end
         end
         ret

--- a/spec/swagger/diff/specification_spec.rb
+++ b/spec/swagger/diff/specification_spec.rb
@@ -176,4 +176,35 @@ describe Swagger::Diff::Specification do
                                                   'key2 (type: string)']) })
     end
   end
+
+  describe 'formData' do
+    let(:parsed) do
+      { 'swagger' => '2.0',
+        'info' => { 'title' => 'Swagger Fixture', 'version' => '1.0' },
+        'paths' =>
+       { '/a/' =>
+        { 'post' =>
+         { 'parameters' =>
+          [{ 'name' => 'w',
+             'in' => 'formData',
+             'required' => false,
+             'type' => 'string' },
+           { 'name' => 'x',
+             'in' => 'formData',
+             'required' => true,
+             'type' => 'string' }],
+           'responses' =>
+          { '204' => {} } } } } }
+    end
+    let(:spec) do
+      Swagger::Diff::Specification.new(parsed)
+    end
+
+    it 'parses params' do
+      expect(spec.request_params)
+        .to eq('post /a/' => { required: Set.new(['x']),
+                               all: Set.new(['w (type: string)',
+                                             'x (type: string)']) })
+    end
+  end
 end


### PR DESCRIPTION
@gburt please review?

The initial logic was incorrect, assuming all `in` values other than "query" and "path" were schema references. This broke "header" and "formData" parameters, by assuming they were references (they were completely dropped on the floor). Fixing the conditional to only treat "body" parameters as references.

Fixes #6.