### PR TITLE
Make it easier to contribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,2 @@
 language: ruby
 cache: bundler
-script:
-  - bundle exec rubocop
-  - bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 1.0.3 (TBD)
 
+### Changes
+
+* Added a default Rake task to run Rubocop and RSpec
+* Added [CONTRIBUTING.md](CONTRIBUTING.md)
+
 ### Bugs Fixed
 
 * [#8](https://github.com/civisanalytics/swagger-diff/pull/8)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing to Swagger::Diff
+
+We welcome Pull Requests from everyone!
+
+## Getting Started
+
+1. Fork it ( https://github.com/civisanalytics/swagger-diff/fork )
+2. Install the development dependencies (`bundle install`)
+3. Make sure you are able to run the test suite locally (`rake`)
+4. Create a feature branch (`git checkout -b my-new-feature`)
+5. Make your change. Don't forget tests
+6. Make sure the test suite, including your new tests, passes (`rake`)
+7. Commit your changes (`git commit -am 'Add some feature'`)
+8. Push to the branch (`git push origin my-new-feature`)
+9. Create a new Pull Request
+10. If the Travis build fails, address any issues
+
+## Tips
+
+- All Pull Requests must include test coverage. If you’re not sure how to test
+  your changes, feel free to ask for help.
+- Contributions must conform to the
+  [Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide).
+- Don’t forget to add your change to the [CHANGELOG](CHANGELOG.md). See
+  [Keep a CHANGELOG](http://keepachangelog.com/) for guidelines.
+
+Thank you for taking the time to contribute to Swagger::Diff!

--- a/README.md
+++ b/README.md
@@ -116,11 +116,7 @@ To release a new version, update the version number in `version.rb`, and then ru
 
 ## Contributing
 
-1. Fork it ( https://github.com/civisanalytics/swagger-diff/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+See [CONTRIBUTING](CONTRIBUTING.md).
 
 ## License
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,9 @@
 require 'bundler/gem_tasks'
+
+require 'rspec/core/rake_task'
+RSpec::Core::RakeTask.new
+
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task default: [:rubocop, :spec]


### PR DESCRIPTION
@christophermanning please review?

Adding a CONTRIBUTING.md with tips for contributions. Adding Rubocop and RSpec Rake tasks and creating a default task so contributors can simply run `rake` to run both Rubocop and RSpec.