### PR TITLE
Allow definitions without properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.4 (TBD)
+
+### Bugs Fixed
+
+* [#14](https://github.com/civisanalytics/swagger-diff/pull/14)
+  allow schema definitions without properties
+
 ## 1.0.3 (2015-11-04)
 
 ### Changes

--- a/lib/swagger/diff/patch.rb
+++ b/lib/swagger/diff/patch.rb
@@ -13,3 +13,17 @@ OAUTH2_PARAMS = [:flow, :authorizationUrl, :scopes]
 Swagger::V2::SecurityScheme.required_properties.reject! do |k, _|
   OAUTH2_PARAMS.include?(k)
 end
+
+# Workaround for Swagger::V2::Operation[1] not including deprecated. Patching
+# pending a merge/release of #11[2].
+#
+# [1] https://github.com/swagger-rb/swagger-rb/blob/master/lib/swagger/v2/operation.rb
+# [2] https://github.com/swagger-rb/swagger-rb/pull/12/files
+
+module Swagger
+  module V2
+    class Operation
+      field :deprecated, String
+    end
+  end
+end

--- a/lib/swagger/diff/specification.rb
+++ b/lib/swagger/diff/specification.rb
@@ -96,7 +96,7 @@ module Swagger
               merge_refs!(ret, properties(schema.properties, schema.required, prefix))
             end
           end
-        else
+        elsif definitions[key].key?('properties')
           merge_refs!(ret,
                       properties(definitions[key].properties,
                                  definitions[key].required, prefix))

--- a/spec/swagger/diff/specification_spec.rb
+++ b/spec/swagger/diff/specification_spec.rb
@@ -208,4 +208,26 @@ describe Swagger::Diff::Specification do
                                              'x (in: formData, type: string)']) })
     end
   end
+
+  describe 'definitions' do
+    let(:parsed) do
+      { 'swagger' => '2.0',
+        'info' => { 'title' => 'Swagger Fixture', 'version' => '1.0' },
+        'paths' =>
+        { '/a/' =>
+          { 'get' =>
+            { 'responses' =>
+              { '200' =>
+                { 'schema' => { '$ref' => '#/definitions/no_props' } } } } } },
+        'definitions' =>
+        { 'no_props' => { 'type' => 'object' } } }
+    end
+    let(:spec) do
+      Swagger::Diff::Specification.new(parsed)
+    end
+
+    it 'can be parsed without properties' do
+      expect { spec.response_attributes }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
@christophermanning please review?

The Swagger specification allows definitions without properties. This fixes an exception when parsing definitions without properties. The example JSON provided also hit an issue with swagger-core, so I folded in that fix, too, as the fix for that issue is still outstanding.

Fixes #13.