### PR TITLE
Parse non-ref parameter schemas.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 1.0.5 (TBD)
+
+### Bugs Fixed
+
+* [#18](https://github.com/civisanalytics/swagger-diff/pull/18)
+  parse non-ref parameter schemas (`allOf`, `properties`, and `items`)
+
 ## 1.0.4 (2015-11-11)
 
 ### Bugs Fixed

--- a/lib/swagger/diff/specification.rb
+++ b/lib/swagger/diff/specification.rb
@@ -192,7 +192,7 @@ module Swagger
         return ret if params.nil?
         params.each do |param|
           if param.in == 'body'
-            merge_refs!(ret, refs(param.schema['$ref']))
+            merge_refs!(ret, schema(param.schema))
           else
             ret[:required].add(param.name) if param.required
             ret[:all].add("#{param.name} (in: #{param.in}, type: #{param.type})")

--- a/spec/swagger/diff/specification_spec.rb
+++ b/spec/swagger/diff/specification_spec.rb
@@ -231,6 +231,30 @@ describe Swagger::Diff::Specification do
       end
     end
 
+    describe 'parameters' do
+      let(:paths) do
+        { '/a/' =>
+          { 'post' =>
+            { 'parameters' =>
+              [{ 'name' => 'body',
+                 'in' => 'body',
+                 'schema' =>
+                 { 'items' => { '$ref' => '#/definitions/body' },
+                   'type' => 'array' } }],
+              'responses' => { '204' => {} } } } }
+      end
+      let(:definitions) do
+        { 'body' => { 'type' => 'object',
+                      'properties' => { 'b' => { 'type' => 'string' } } } }
+      end
+
+      it 'parses body params that are arrays' do
+        expect(spec.request_params)
+          .to eq('post /a/' => { required: Set.new,
+                                 all: Set.new(['[]/b (in: body, type: string)']) })
+      end
+    end
+
     describe 'responses' do
       let(:paths) do
         { '/a/' =>


### PR DESCRIPTION
@christophermanning please review?

Support Swagger parameter schemas using an `allOf`, directly specifying properties, or using an array of `$ref`s.

Fixes #17.