### PR TITLE
RuboCop fix

### DIFF
--- a/lib/swagger/diff/diff.rb
+++ b/lib/swagger/diff/diff.rb
@@ -170,7 +170,7 @@ module Swagger
         enumerator = changed_response_attributes_enumerator(
           @new_specification,
           @old_specification,
-          'new attribute for %{code} response: %<resp>s',
+          'new attribute for %<code>s response: %<resp>s',
           'new %<code>s response'
         )
         change_hash(enumerator)


### PR DESCRIPTION
Apparently RuboCop complains about `'new attribute for %{code} response: %{resp}'`, but not `'new attribute for %{code} response: %<resp>s'`, and I missed the 2nd use in this line in #45. Fixed.