### PR TITLE
Parse nested inline objects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
 
 Metrics/ClassLength:
-  Max: 240
+  Max: 250
 
 Metrics/LineLength:
   Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Bumped the Travis matrix to 2.1.10, 2.2.7, and 2.3.4
 * RuboCop fixes
 
+### Fixed
+
+* [#51](https://github.com/civisanalytics/swagger-diff/pull/51)
+  parse nested inline objects
+
 ## [1.1.0] - 2016-05-20
 
 ### Added

--- a/lib/swagger/diff/specification.rb
+++ b/lib/swagger/diff/specification.rb
@@ -211,6 +211,7 @@ module Swagger
         "#{key} (in: body, type: Hash[string, #{type}])"
       end
 
+      # rubocop:disable Metrics/CyclomaticComplexity
       def properties(properties, required, prefix = '')
         ret = { required: Set.new, all: Set.new }
         properties.each do |name, schema|
@@ -219,6 +220,8 @@ module Swagger
           elsif schema['type'] == 'object'
             if schema['allOf']
               # TODO: handle nested allOfs.
+            elsif schema['type'] && schema['type'] == 'object' && schema['properties']
+              merge_refs!(ret, properties(schema['properties'], required, "#{prefix}#{name}/"))
             else
               ret[:all].add(hash_property(schema, prefix, name))
             end
@@ -228,6 +231,7 @@ module Swagger
         end
         ret
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def request_params_inner(params)
         ret = { required: Set.new, all: Set.new }

--- a/spec/swagger/diff/specification_spec.rb
+++ b/spec/swagger/diff/specification_spec.rb
@@ -444,6 +444,34 @@ The property '#/paths//a//get' did not contain a required property of 'responses
       end
     end
 
+    describe 'nested inline response objects' do
+      let(:paths) do
+        { '/a/' =>
+          { 'get' =>
+            { 'responses' =>
+              { '200' =>
+                { '$ref' => '#/responses/200' } } } } }
+      end
+      let(:responses) do
+        { '200' => { 'description' => 'A generic response',
+                     'schema' =>
+                     { 'type' => 'object',
+                       'properties' =>
+                       { 'nested' =>
+                         { 'type' => 'object',
+                           'properties' =>
+                           { 'id' => { 'type' => 'integer' },
+                             'name' => { 'type' => 'string' } } } } } } }
+      end
+
+      it 'recurses' do
+        expect(spec.response_attributes)
+          .to eq('get /a/' =>
+                 { '200' => Set.new(['nested/id (in: body, type: integer)',
+                                     'nested/name (in: body, type: string)']) })
+      end
+    end
+
     describe 'external path item' do
       let(:paths) do
         { '/a/' => { '$ref' => '...' } }


### PR DESCRIPTION
Adding support for parsing objects like:

```
    "MyObject": {
      "type": "object",
      "properties": {
        "myProperty": {
          "type": "object",
          "properties": {
            "myNestedProperty": {
              "type": "boolean"
            }
          }
        }
      }
    }
```

Previously, this would be parsed as `MyObject/myProperty (in: body, type: Hash[string, *])`. Now this is parsed as `MyObject/myProperty/myNestedProperty (in: body, type: boolean)`.

Fixes #50.