### PR TITLE
Recursively parse non-ref response schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+* [#56](https://github.com/civisanalytics/swagger-diff/pull/56)
+  recursively parse non-ref response schemas (`properties` and `items`)
+
 ## [1.1.1] - 2017-08-23
 
 ### Added

--- a/lib/swagger/diff/specification.rb
+++ b/lib/swagger/diff/specification.rb
@@ -187,9 +187,9 @@ module Swagger
 
       def properties_for_ref(prefix, name, schema, required, list = false)
         ret = { required: Set.new, all: Set.new }
-        if schema.key?('$ref')
+        if schema['$ref']
           merge_refs!(ret, nested(schema['$ref'], prefix, name, list))
-        elsif schema.key?('properties')
+        elsif schema['properties']
           prefix = "#{name}#{'[]' if list}/"
           merge_refs!(ret, properties(schema['properties'], schema['required'], prefix))
         else
@@ -225,7 +225,7 @@ module Swagger
         properties.each do |name, schema|
           if schema['type'] == 'array'
             merge_refs!(ret, properties_for_ref(prefix, name, schema['items'], required, true))
-          elsif schema['type'] == 'object' || schema.key?('properties')
+          elsif schema['type'] == 'object' || schema['properties']
             if schema['allOf']
               # TODO: handle nested allOfs.
             elsif schema['properties']

--- a/spec/swagger/diff/specification_spec.rb
+++ b/spec/swagger/diff/specification_spec.rb
@@ -420,6 +420,37 @@ The property '#/paths//a//get' did not contain a required property of 'responses
       end
     end
 
+    describe 'response properties' do
+      let(:paths) do
+        { '/a/' =>
+          { 'get' =>
+            { 'responses' =>
+              { '200' =>
+                { 'description' => 'A generic response',
+                  'schema' =>
+                  { 'properties' =>
+                    { 'data' =>
+                      { 'type' => 'array',
+                        'items' =>
+                        { 'properties' =>
+                          { 'obj' =>
+                            { 'properties' =>
+                              { 'id' => { 'type' => 'integer' },
+                                'name' => { 'type' => 'string' },
+                                'strings' =>
+                                { 'type' => 'array',
+                                  'items' => { 'type' => 'string' } } } } } } } } } } } } } }
+      end
+
+      it 'parses properties recursively' do
+        expect(spec.response_attributes)
+          .to eq('get /a/' =>
+                 { '200' => Set.new(['data[]/obj/id (in: body, type: integer)',
+                                     'data[]/obj/name (in: body, type: string)',
+                                     'data[]/obj/strings (in: body, type: string[])']) })
+      end
+    end
+
     describe 'response refs' do
       let(:paths) do
         { '/a/' =>


### PR DESCRIPTION
Correctly parse:
```
schema:
  properties:
    key:
      type: array
      items:
        type: object
        properties:
          ...
```
,
```
schema:
  properties:
    key:
      type: array
      items:
        type: object
        properties:
          key:
            type: object
            properties:
              ...
```
, and
```
schema:
  properties:
    key:
      type: array
      items:
        type: object
        properties:
          key:
            type: array
            items:
              ...
```

Fixes #43.